### PR TITLE
debug: Add hardware breakpoints

### DIFF
--- a/litex/data/vexriscv/verilog/Makefile
+++ b/litex/data/vexriscv/verilog/Makefile
@@ -6,31 +6,31 @@ VexRiscv.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault"
 
 VexRiscv_Debug.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault -d --outputFile VexRiscv_Debug"
+	sbt compile "runMain vexriscv.GenCoreDefault -d --hardwareBreakpointCount 2 --outputFile VexRiscv_Debug"
 
 VexRiscv_Lite.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --iCacheSize 2048 --dCacheSize 0 --mulDiv true --singleCycleShift false --singleCycleMulDiv false  --outputFile VexRiscv_Lite"
 
 VexRiscv_LiteDebug.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault -d --iCacheSize 2048 --dCacheSize 0 --mulDiv true --singleCycleShift false --singleCycleMulDiv false --outputFile VexRiscv_LiteDebug"
+	sbt compile "runMain vexriscv.GenCoreDefault -d --hardwareBreakpointCount 2 --iCacheSize 2048 --dCacheSize 0 --mulDiv true --singleCycleShift false --singleCycleMulDiv false --outputFile VexRiscv_LiteDebug"
 
 VexRiscv_Min.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --iCacheSize 0 --dCacheSize 0 --mulDiv false --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --outputFile VexRiscv_Min"
 
 VexRiscv_MinDebug.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault -d --iCacheSize 0 --dCacheSize 0 --mulDiv false --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --outputFile VexRiscv_MinDebug"
+	sbt compile "runMain vexriscv.GenCoreDefault -d --hardwareBreakpointCount 2 --iCacheSize 0 --dCacheSize 0 --mulDiv false --singleCycleShift false --singleCycleMulDiv false --bypass false --prediction none --outputFile VexRiscv_MinDebug"
 
 VexRiscv_Full.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all --outputFile VexRiscv_Full"
 
 VexRiscv_FullDebug.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all -d --outputFile VexRiscv_FullDebug"
+	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all -d --hardwareBreakpointCount 2 --outputFile VexRiscv_FullDebug"
 
 VexRiscv_Linux.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig linux-minimal --outputFile VexRiscv_Linux"
 
 VexRiscv_LinuxDebug.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig linux-minimal -d --outputFile VexRiscv_LinuxDebug"
+	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig linux-minimal -d --hardwareBreakpointCount 2 --outputFile VexRiscv_LinuxDebug"
 
 VexRiscv_LinuxNoDspFmax.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig linux-minimal --singleCycleMulDiv=false --relaxedPcCalculation=true --prediction=none --outputFile VexRiscv_LinuxNoDspFmax"

--- a/litex/data/vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/litex/data/vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -21,6 +21,7 @@ object SpinalConfig extends spinal.core.SpinalConfig(
 
 case class ArgConfig(
   debug : Boolean = false,
+  hardwareBreakpointCount : Int = 0,
   iCacheSize : Int = 4096,
   dCacheSize : Int = 4096,
   mulDiv : Boolean = true,
@@ -53,6 +54,7 @@ object GenCoreDefault{
     val parser = new scopt.OptionParser[ArgConfig]("VexRiscvGen") {
       //  ex :-d    or   --debug
       opt[Unit]('d', "debug")    action { (_, c) => c.copy(debug = true)   } text("Enable debug")
+      opt[Int]("hardwareBreakpointCount")    action { (_, c) => c.copy(hardwareBreakpointCount = v)   } text("Set number of hardware breakpoints, 0 means none, only valid when debug enabled")
       // ex : -iCacheSize=XXX
       opt[Int]("iCacheSize")     action { (v, c) => c.copy(iCacheSize = v) } text("Set instruction cache size, 0 mean no cache")
       // ex : -dCacheSize=XXX
@@ -215,7 +217,7 @@ object GenCoreDefault{
 
       // Add in the Debug plugin, if requested
       if(argConfig.debug) {
-        plugins += new DebugPlugin(ClockDomain.current.clone(reset = Bool().setName("debugReset")))
+        plugins += new DebugPlugin(ClockDomain.current.clone(reset = Bool().setName("debugReset")), hardwareBreakpointCount = argConfig.hardwareBreakpointCount)
       }
 
       // CPU configuration


### PR DESCRIPTION
Related to https://github.com/enjoy-digital/litex/issues/344

This is just an example of the changes required to enable hardware breakpoints in the VexRiscv configuration. I have not updated the VexRiscv cores themselves.